### PR TITLE
fixes syntax issues in docker-compose file

### DIFF
--- a/root/salt/docker-compose.yml
+++ b/root/salt/docker-compose.yml
@@ -1,9 +1,11 @@
-version: '2'
+version: '3'
 services:
   salt-master:
     image: ubuntu:latest
     container_name: salt-master
-    build:  SaltMaster_DockerFile
+    build:
+      context: ./
+      dockerfile: SaltMaster_DockerFile
     ports:
       - "443:443"
       - "80:80"


### PR DESCRIPTION
Proof that this works:

```
[root@saltmaster salt]# docker-compose build
Building salt-master
Step 1/3 : FROM ubuntu:latest
latest: Pulling from library/ubuntu
124c757242f8: Pull complete
9d866f8bde2a: Pull complete
fa3f2f277e67: Pull complete
398d32b153e8: Pull complete
afde35469481: Pull complete
Digest: sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378
Status: Downloaded newer image for ubuntu:latest
 ---> cd6d8154f1e1
Step 2/3 : WORKDIR '$HOME'
Removing intermediate container 31be0d9a9218
 ---> 50a1e7b0a9f2
Step 3/3 : RUN   echo " salt master is installed "
 ---> Running in 150674e16d19
 salt master is installed
Removing intermediate container 150674e16d19
 ---> 3cbc9f1d5c80
Successfully built 3cbc9f1d5c80
Successfully tagged ubuntu:latest
[root@saltmaster salt]#
```